### PR TITLE
zig fmt + some fixes for Zig 0.11 release

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -25,7 +25,7 @@ pub fn ptrAlign(comptime Ptr: type) comptime_int {
 }
 
 pub fn ptrAlignCast(comptime Ptr: type, ptr: anytype) Ptr {
-    return @ptrCast(Ptr, @alignCast(ptrAlign(Ptr), ptr));
+    return @ptrCast(@alignCast(ptr));
 }
 
 pub fn ptrfmt(ptr: anytype) PtrFmt {

--- a/src/conformance.zig
+++ b/src/conformance.zig
@@ -28,7 +28,7 @@ pub fn main() !void {
 fn serializeTo(serializable: anytype, writer: anytype) !void {
     var countwriter = std.io.countingWriter(std.io.null_writer);
     try pb.protobuf.serialize(&serializable.base, countwriter.writer());
-    try writer.writeIntLittle(u32, @intCast(u32, countwriter.bytes_written));
+    try writer.writeIntLittle(u32, @as(u32, @intCast(countwriter.bytes_written)));
     try pb.protobuf.serialize(&serializable.base, writer);
 }
 

--- a/src/gen-c.zig
+++ b/src/gen-c.zig
@@ -179,8 +179,8 @@ fn writeCMacroName(
     // nested messages and enums have 'parent names' which need to be included.
     // field names (.named) are absolute and don't need parent names included.
     if (switch (node) {
-        .enum_ => |ptr| @ptrCast(?*const anyopaque, ptr),
-        .message => |ptr| @ptrCast(?*const anyopaque, ptr),
+        .enum_ => |ptr| @as(?*const anyopaque, @ptrCast(ptr)),
+        .message => |ptr| @as(?*const anyopaque, @ptrCast(ptr)),
         .named => null,
     }) |id| blk: {
         const parent = ctx.?.parents.get(id) orelse break :blk;
@@ -480,8 +480,8 @@ pub fn writeCName(
     // nested messages and enums have 'parent names' which need to be included.
     // field names (.named) are absolute and don't need parent names included.
     if (switch (node) {
-        .enum_ => |ptr| @ptrCast(?*const anyopaque, ptr),
-        .message => |ptr| @ptrCast(?*const anyopaque, ptr),
+        .enum_ => |ptr| @as(?*const anyopaque, @ptrCast(ptr)),
+        .message => |ptr| @as(?*const anyopaque, @ptrCast(ptr)),
         .named => null,
     }) |id| blk: {
         const parent = ctx.?.parents.get(id) orelse break :blk;

--- a/src/gen-zig.zig
+++ b/src/gen-zig.zig
@@ -432,7 +432,7 @@ pub fn genFieldDescriptors(
             \\
         , .{
             if (is_oneof)
-                message.oneof_decl.items[@intCast(usize, field.oneof_index)].name
+                message.oneof_decl.items[@as(usize, @intCast(field.oneof_index))].name
             else
                 field.name,
         });

--- a/src/gen.zig
+++ b/src/gen.zig
@@ -322,7 +322,7 @@ pub fn genPopulateMaps(ctx: *Context) !void {
 pub fn gen(ctx: *Context) !CodeGeneratorResponse {
     var res = CodeGeneratorResponse.init();
     try genPopulateMaps(ctx);
-    res.set(.supported_features, @intCast(u64, @intFromEnum(CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL)));
+    res.set(.supported_features, @as(u64, @intCast(@intFromEnum(CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL))));
 
     if (output_format == .c) {
         log.err("TODO support output_format == .c", .{});

--- a/src/google/protobuf/descriptor.pb.zig
+++ b/src/google/protobuf/descriptor.pb.zig
@@ -1648,7 +1648,7 @@ pub const GeneratedCodeInfo = extern struct {
         source_file: String = String.empty,
         begin: i32 = 0,
         end: i32 = 0,
-        semantic: GeneratedCodeInfo.Annotation.Semantic = @enumFromInt(GeneratedCodeInfo.Annotation.Semantic, 0),
+        semantic: GeneratedCodeInfo.Annotation.Semantic = @enumFromInt(0),
 
         pub const field_ids = [_]c_uint{ 1, 2, 3, 4, 5 };
         pub const opt_field_ids = [_]c_uint{ 2, 3, 4, 5 };

--- a/src/json.zig
+++ b/src/json.zig
@@ -132,7 +132,7 @@ pub fn serializeImpl(
     );
     // std.debug.print("+++ serialize {}", .{desc.name});
     try pb.protobuf.verifyMessageType(desc.magic, types.MESSAGE_DESCRIPTOR_MAGIC);
-    const buf = @ptrCast([*]const u8, message)[0..desc.sizeof_message];
+    const buf = @as([*]const u8, @ptrCast(message))[0..desc.sizeof_message];
 
     try writer.writeByte('{');
     var child_options = options;
@@ -305,7 +305,7 @@ fn serializeField(
                 try serializeFloat(float, writer);
             }
         } else try serializeFloat(
-            @bitCast(f32, mem.readIntLittle(u32, member[0..4])),
+            @as(f32, @bitCast(mem.readIntLittle(u32, member[0..4]))),
             writer,
         ),
         .TYPE_DOUBLE => if (child_info.is_repeated) {
@@ -316,7 +316,7 @@ fn serializeField(
                 try serializeFloat(d, writer);
             }
         } else try serializeFloat(
-            @bitCast(f64, mem.readIntLittle(u64, member[0..8])),
+            @as(f64, @bitCast(mem.readIntLittle(u64, member[0..8]))),
             writer,
         ),
         .TYPE_STRING => if (child_info.is_repeated) {
@@ -372,7 +372,7 @@ fn serializeField(
                     try serializeField(
                         FieldInfo.init(
                             key_field,
-                            @ptrCast([*]const u8, subm) + key_field.offset,
+                            @as([*]const u8, @ptrCast(subm)) + key_field.offset,
                             false,
                             child_info.options,
                         ),

--- a/src/protobuf-types.zig
+++ b/src/protobuf-types.zig
@@ -182,7 +182,7 @@ fn fieldIndicesByName(comptime field_descriptors: []const FieldDescriptor) []con
         }
     }.lessThan;
     for (field_descriptors, 0..) |fd, i|
-        tups[i] = .{ @intCast(c_uint, i), fd.name.slice() };
+        tups[i] = .{ @as(c_uint, @intCast(i)), fd.name.slice() };
     std.sort.sort(Tup, &tups, {}, lessThan);
     var result: [field_descriptors.len]c_uint = undefined;
     for (tups, 0..) |tup, i| result[i] = tup[0];
@@ -544,7 +544,7 @@ pub const Message = extern struct {
         const desc = m.descriptor orelse unreachable;
         const opt_field_idx = desc.optionalFieldIndex(field_id) orelse
             return true;
-        return (m.optional_fields_present >> @intCast(u6, opt_field_idx)) & 1 != 0;
+        return (m.optional_fields_present >> @as(u6, @intCast(opt_field_idx))) & 1 != 0;
     }
 
     /// set `m.optional_fields_present` at the field index corresponding to
@@ -554,7 +554,7 @@ pub const Message = extern struct {
             @panic("called setPresent() on a message with no descriptor.");
         log.debug("setPresent({})", .{field_id});
         const opt_field_idx = desc.optionalFieldIndex(field_id) orelse return;
-        m.optional_fields_present |= @as(u64, 1) << @intCast(u6, opt_field_idx);
+        m.optional_fields_present |= @as(u64, 1) << @as(u6, @intCast(opt_field_idx));
         log.debug("setPresent 2 m.optional_fields_present {b:0>64}", .{m.optional_fields_present});
         // TODO if oneof field, remove other fields w/ same oneof_index
     }
@@ -567,9 +567,9 @@ pub const Message = extern struct {
         log.debug("setPresentValue({}, {})", .{ field_id, value });
         const opt_field_idx = desc.optionalFieldIndex(field_id) orelse return;
         if (value)
-            m.optional_fields_present |= @as(u64, 1) << @intCast(u6, opt_field_idx)
+            m.optional_fields_present |= @as(u64, 1) << @as(u6, @intCast(opt_field_idx))
         else
-            m.optional_fields_present &= ~(@as(u64, 1) << @intCast(u6, opt_field_idx));
+            m.optional_fields_present &= ~(@as(u64, 1) << @as(u6, @intCast(opt_field_idx)));
         log.debug("setPresentValue 2 m.optional_fields_present {b:0>64}", .{m.optional_fields_present});
         // TODO if oneof field, remove other fields w/ same oneof_index
     }
@@ -589,14 +589,14 @@ pub const Message = extern struct {
             log.err("expected '{s}' to contain '{s}'", .{ @typeName(T), m.descriptor.?.name });
             return error.TypeMismatch;
         }
-        return @ptrCast(*T, m);
+        return @as(*T, @ptrCast(m));
     }
 
     pub fn formatMessage(message: *const Message, writer: anytype) WriteErr!void {
         const desc = message.descriptor orelse unreachable;
         try writer.print("{s}{{", .{desc.name});
         const fields = desc.fields;
-        const bytes = @ptrCast([*]const u8, message);
+        const bytes = @as([*]align(@alignOf(*Message)) const u8, @ptrCast(message));
         for (fields.slice(), 0..) |f, i| {
             const member = bytes + f.offset;
             const field_id = desc.field_ids.items[i];
@@ -652,7 +652,7 @@ pub const Message = extern struct {
                             try writer.print("{}", .{it});
                         }
                         _ = try writer.write("}");
-                    } else try writer.print(".{s} = {}", .{ field_name, @bitCast(i32, member[0..4].*) });
+                    } else try writer.print(".{s} = {}", .{ field_name, @as(i32, @bitCast(member[0..4].*)) });
                 },
                 .TYPE_UINT32, .TYPE_FIXED32 => {
                     if (f.label == .LABEL_REPEATED) {
@@ -664,7 +664,7 @@ pub const Message = extern struct {
                             try writer.print("{}", .{it});
                         }
                         _ = try writer.write("}");
-                    } else try writer.print(".{s} = {}", .{ field_name, @bitCast(u32, member[0..4].*) });
+                    } else try writer.print(".{s} = {}", .{ field_name, @as(u32, @bitCast(member[0..4].*)) });
                 },
                 .TYPE_INT64, .TYPE_SINT64, .TYPE_SFIXED64 => {
                     if (f.label == .LABEL_REPEATED) {
@@ -676,7 +676,7 @@ pub const Message = extern struct {
                             try writer.print("{}", .{it});
                         }
                         _ = try writer.write("}");
-                    } else try writer.print(".{s} = {}", .{ field_name, @bitCast(i64, member[0..8].*) });
+                    } else try writer.print(".{s} = {}", .{ field_name, @as(i64, @bitCast(member[0..8].*)) });
                 },
                 .TYPE_UINT64, .TYPE_FIXED64 => {
                     if (f.label == .LABEL_REPEATED) {
@@ -688,7 +688,7 @@ pub const Message = extern struct {
                             try writer.print("{}", .{it});
                         }
                         _ = try writer.write("}");
-                    } else try writer.print(".{s} = {}", .{ field_name, @bitCast(u64, member[0..8].*) });
+                    } else try writer.print(".{s} = {}", .{ field_name, @as(u64, @bitCast(member[0..8].*)) });
                 },
                 .TYPE_FLOAT => {
                     if (f.label == .LABEL_REPEATED) {
@@ -700,7 +700,7 @@ pub const Message = extern struct {
                             try writer.print("{}", .{it});
                         }
                         _ = try writer.write("}");
-                    } else try writer.print(".{s} = {}", .{ field_name, @bitCast(f32, member[0..4].*) });
+                    } else try writer.print(".{s} = {}", .{ field_name, @as(f32, @bitCast(member[0..4].*)) });
                 },
                 .TYPE_DOUBLE => {
                     if (f.label == .LABEL_REPEATED) {
@@ -712,7 +712,7 @@ pub const Message = extern struct {
                             try writer.print("{}", .{it});
                         }
                         _ = try writer.write("}");
-                    } else try writer.print(".{s} = {}", .{ field_name, @bitCast(f64, member[0..8].*) });
+                    } else try writer.print(".{s} = {}", .{ field_name, @as(f64, @bitCast(member[0..8].*)) });
                 },
                 else => {
                     todo(".{s} .{s}", .{ @tagName(f.type), @tagName(f.label) });
@@ -742,7 +742,7 @@ pub const Message = extern struct {
         allocator: mem.Allocator,
         mode: enum { all_fields, only_pointer_fields },
     ) void {
-        const bytes = @ptrCast([*]u8, m);
+        const bytes = @as([*]align(@alignOf(*Message)) u8, @ptrCast(m));
         const desc = m.descriptor orelse
             panicf("can't deinit a message with no descriptor.", .{});
 
@@ -805,7 +805,7 @@ pub const Message = extern struct {
                             .TYPE_SFIXED64,
                             .TYPE_SINT64,
                             => {
-                                const ptr = @alignCast(8, list.items);
+                                const ptr: [*]align(8) u8 = @ptrCast(@alignCast(list.items));
                                 allocator.free(ptr[0 .. size * list.cap]);
                             },
                             .TYPE_FLOAT,
@@ -817,7 +817,7 @@ pub const Message = extern struct {
                             .TYPE_SINT32,
                             .TYPE_BOOL,
                             => {
-                                const ptr = @alignCast(4, list.items);
+                                const ptr: [*]align(4) u8 = @ptrCast(@alignCast(list.items));
                                 allocator.free(ptr[0 .. size * list.cap]);
                             },
                             else => {
@@ -835,7 +835,7 @@ pub const Message = extern struct {
                     );
                     var subm = ptrAlignCast(**Message, bytes + field.offset);
                     deinitImpl(subm.*, allocator, .only_pointer_fields);
-                    const subbytes = @ptrCast([*]u8, subm.*);
+                    const subbytes = @as([*]align(@alignOf(*Message)) u8, @ptrCast(subm.*));
                     const subdesc = subm.*.descriptor orelse
                         panicf("can't deinit a message with no descriptor.", .{});
                     allocator.free(subbytes[0..subdesc.sizeof_message]);

--- a/src/test-common.zig
+++ b/src/test-common.zig
@@ -60,7 +60,7 @@ pub fn encodeInt(comptime T: type, i: T) []const u8 {
 
 pub fn encodeFloat(comptime T: type, i: T) []const u8 {
     const U = std.meta.Int(.unsigned, @typeInfo(T).Float.bits);
-    return encodeInt(U, @bitCast(U, i));
+    return encodeInt(U, @as(U, @bitCast(i)));
 }
 
 pub fn encodeMessage(comptime parts: anytype) []const u8 {
@@ -165,10 +165,10 @@ pub fn testInit(
 ) mem.Allocator.Error!T {
     @setEvalBranchQuota(10_000);
     switch (@typeInfo(T)) {
-        .Int => return @intCast(T, field_id.?),
+        .Int => return @as(T, @intCast(field_id.?)),
         .Bool => return true,
         .Enum => return std.meta.tags(T)[0],
-        .Float => return @floatFromInt(T, field_id.?),
+        .Float => return @as(T, @floatFromInt(field_id.?)),
         .Struct => if (T == String) {
             return String.init(try std.fmt.allocPrint(alloc, "{}", .{field_id.?}));
         } else if (comptime mem.indexOf(


### PR DESCRIPTION
I have a personal project I wanted to update to 0.11 that depends on protobuf-zig - thought I would send out a PR updating this library to Zig 0.11 in case it saves you some time.

I just ran zig fmt and then fixed up 3 or 4 alignment issues that were showing up in the tests on free. Some of the @as from zig fmt could probably be cleaned up.

All tests pass without issue on my machine